### PR TITLE
Add a Makefile and tell the compiler to optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 .vscode
-a.out
+*.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+genetic.out: genetic.cpp
+	$(CXX) --std=c++11 $< -o $@
+
+.PHONY: clean bench
+
+bench: genetic.out
+	hyperfine --warmup 3 ./genetic.out
+
+clean:
+	rm -f *.out

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 genetic.out: genetic.cpp
-	$(CXX) --std=c++11 $< -o $@
+	$(CXX) -O3 --std=c++11 $< -o $@
 
 .PHONY: clean bench
 


### PR DESCRIPTION
This PR adds a Makefile.

Makefiles have several benefits:

1. I don't need to figure out which flags you have GCC to compile (`--std=c++11`)
2. I can add other scripts to do helpful things, like clean build products or run benchmarking suites

Speaking of benchmarking, I added one extra flag to the gcc invocation: `-O3`.

> For some discussion on optimization levels, see <https://stackoverflow.com/questions/19689014/gcc-difference-between-o3-and-os>

To run the benchmarks, you'll need `hyperfine`: <https://github.com/sharkdp/hyperfine>


As of b0dd3194eceebc8e259cbb35c7af55150ee03023, `genetic` ran in about 3.5s.

```
$ make bench
Benchmark #1: ./genetic.out
  Time (mean ± σ):      3.546 s ±  0.113 s    [User: 3.529 s, System: 0.012 s]
  Range (min … max):    3.453 s …  3.769 s    10 runs
```

In 768a9764c7e56369216bc72789f4b6864e6bcdf3, though, just by adding `-O3`, it drops to 1.4s.

```
$ make bench
Benchmark #1: ./genetic.out
  Time (mean ± σ):      1.411 s ±  0.041 s    [User: 1.400 s, System: 0.008 s]
  Range (min … max):    1.374 s …  1.490 s    10 runs
```
